### PR TITLE
Add Tamil lyric model training scripts and web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,48 @@ tokenizer.decode(toks.ids)
 
 A Jupyter notebook tutorial [tutorial](/tutorial.ipynb) is also available to build a tokenizer model, followed by loading and using it for tokenizing Tamil and Malayalam texts.
 
+## Tamil Language Model and Lyrics Generator
+
+This project now includes utilities for building a tiny Tamil language model and generating song lyrics.
+
+### 1. Pre-train a Tiny Tamil Model
+
+Download a small portion of the open [IndicCorp](https://huggingface.co/datasets/ai4bharat/IndicCorp) dataset and run:
+
+```bash
+python scripts/pretrain_tamil_gpt.py \
+  --samples 1000 \
+  --output_dir tamil-pretrained \
+  --tokenizer_path path/to/indic-bert-tokenizer-vocab.txt
+```
+
+The script trains a compact GPT-2 style model from scratch using the provided Indic tokenizer vocabulary and saves it to `tamil-pretrained/`.
+
+### 2. Fine-tune on Tamil Song Lyrics
+
+Obtain a Tamil lyrics dataset from [Hugging Face Datasets](https://huggingface.co/datasets) and fine-tune the pretrained model:
+
+```bash
+python scripts/fine_tune_lyrics.py \
+  --dataset_name <dataset> \
+  --model_dir tamil-pretrained \
+  --output_dir tamil-lyrics-model \
+  --samples 1000 \
+  --tokenizer_path path/to/indic-bert-tokenizer-vocab.txt
+```
+
+Replace `<dataset>` with the dataset identifier (for example, `your-username/tamil-lyrics`). The fine-tuned model and tokenizer are saved to `tamil-lyrics-model/`.
+
+### 3. Web Interface for Lyrics Generation
+
+A simple [Gradio](https://gradio.app) application generates song lyrics for a given theme:
+
+```bash
+python app.py
+```
+
+Enter a theme and the app will produce approximately three minutes of Tamil lyrics using the fine-tuned model.
+
 
 ## Supported Languages
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,34 @@
+import gradio as gr
+from transformers import AutoModelForCausalLM, PreTrainedTokenizerFast
+from indic_unicode_mapper import IndicUnicodeMapper
+
+MODEL_DIR = "tamil-lyrics-model"
+
+tokenizer = PreTrainedTokenizerFast.from_pretrained(MODEL_DIR)
+mapper = IndicUnicodeMapper()
+model = AutoModelForCausalLM.from_pretrained(MODEL_DIR)
+
+def generate_lyrics(theme: str) -> str:
+    prompt = f"பாடல் தலைப்பு: {theme}\n"
+    mapped = mapper.encode(prompt)
+    input_ids = tokenizer(mapped, return_tensors="pt").input_ids
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=300,
+        do_sample=True,
+        temperature=0.8,
+        top_p=0.95,
+    )
+    raw = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    return mapper.decode(raw)
+
+iface = gr.Interface(
+    fn=generate_lyrics,
+    inputs=gr.Textbox(label="Theme"),
+    outputs=gr.Textbox(label="Lyrics"),
+    title="Tamil Lyrics Generator",
+    description="Provide a theme to generate ~3 minute Tamil song lyrics.",
+)
+
+if __name__ == "__main__":
+    iface.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ tokenizers==0.21.1
 tqdm==4.67.1
 typing_extensions==4.13.2
 urllib3==2.4.0
+datasets
+transformers
+torch
+gradio

--- a/scripts/fine_tune_lyrics.py
+++ b/scripts/fine_tune_lyrics.py
@@ -1,0 +1,68 @@
+import argparse
+from datasets import load_dataset
+from transformers import (
+    GPT2LMHeadModel,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+    PreTrainedTokenizerFast,
+)
+from indic_bert_tokenizer import IndicBertWordPieceTokenizer
+from indic_unicode_mapper import IndicUnicodeMapper
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fine-tune the Tamil model on song lyrics")
+    parser.add_argument("--dataset_name", type=str, required=True, help="HuggingFace dataset containing Tamil lyrics")
+    parser.add_argument("--model_dir", type=str, default="tamil-pretrained", help="path to the pretrained model")
+    parser.add_argument("--output_dir", type=str, default="tamil-lyrics-model", help="where to save the fine-tuned model")
+    parser.add_argument("--samples", type=int, default=1000, help="number of lyric samples to use")
+    parser.add_argument(
+        "--tokenizer_path",
+        type=str,
+        required=True,
+        help="path to Indic tokenizer vocab file",
+    )
+    args = parser.parse_args()
+
+    dataset = load_dataset(args.dataset_name, split=f"train[:{args.samples}]")
+    indic_tok = IndicBertWordPieceTokenizer(args.tokenizer_path)
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=indic_tok._tokenizer._tokenizer,
+        bos_token="[cls]",
+        eos_token="[sep]",
+        unk_token="[unk]",
+        pad_token="[pad]",
+        mask_token="[mask]",
+    )
+    mapper = IndicUnicodeMapper()
+
+    def tokenize_function(examples):
+        mapped = [mapper.encode(t) for t in examples["text"]]
+        return hf_tokenizer(mapped)
+
+    tokenized = dataset.map(tokenize_function, batched=True, remove_columns=dataset.column_names)
+
+    model = GPT2LMHeadModel.from_pretrained(args.model_dir)
+    data_collator = DataCollatorForLanguageModeling(tokenizer=hf_tokenizer, mlm=False)
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        overwrite_output_dir=True,
+        num_train_epochs=3,
+        per_device_train_batch_size=8,
+        save_steps=500,
+        logging_steps=50,
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized,
+        data_collator=data_collator,
+    )
+    trainer.train()
+    trainer.save_model(args.output_dir)
+    hf_tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pretrain_tamil_gpt.py
+++ b/scripts/pretrain_tamil_gpt.py
@@ -1,0 +1,78 @@
+import argparse
+from datasets import load_dataset
+from transformers import (
+    GPT2Config,
+    GPT2LMHeadModel,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+    PreTrainedTokenizerFast,
+)
+from indic_bert_tokenizer import IndicBertWordPieceTokenizer
+from indic_unicode_mapper import IndicUnicodeMapper
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Pre-train a tiny GPT model on Tamil text")
+    parser.add_argument("--samples", type=int, default=1000, help="number of training samples")
+    parser.add_argument("--output_dir", type=str, default="tamil-pretrained", help="where to save the model")
+    parser.add_argument(
+        "--tokenizer_path",
+        type=str,
+        required=True,
+        help="path to Indic tokenizer vocab file",
+    )
+    args = parser.parse_args()
+
+    dataset = load_dataset("ai4bharat/IndicCorp", "ta", split=f"train[:{args.samples}]")
+
+    indic_tok = IndicBertWordPieceTokenizer(args.tokenizer_path)
+    hf_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=indic_tok._tokenizer._tokenizer,
+        bos_token="[cls]",
+        eos_token="[sep]",
+        unk_token="[unk]",
+        pad_token="[pad]",
+        mask_token="[mask]",
+    )
+    mapper = IndicUnicodeMapper()
+
+    def tokenize_function(examples):
+        mapped = [mapper.encode(t) for t in examples["text"]]
+        return hf_tokenizer(mapped)
+
+    tokenized = dataset.map(tokenize_function, batched=True, remove_columns=["text"])
+
+    config = GPT2Config(
+        vocab_size=hf_tokenizer.vocab_size,
+        n_positions=256,
+        n_ctx=256,
+        n_embd=128,
+        n_layer=2,
+        n_head=2,
+    )
+    model = GPT2LMHeadModel(config)
+    data_collator = DataCollatorForLanguageModeling(tokenizer=hf_tokenizer, mlm=False)
+
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        overwrite_output_dir=True,
+        num_train_epochs=1,
+        per_device_train_batch_size=8,
+        save_steps=1000,
+        logging_steps=50,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized,
+        data_collator=data_collator,
+    )
+    trainer.train()
+    trainer.save_model(args.output_dir)
+    hf_tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add tiny GPT pretraining script for Tamil text
- add fine-tuning script for Tamil song lyrics
- create Gradio web app to generate lyrics from a theme
- document new workflow and dependencies
- switch training and inference to repository's Indic tokenizer

## Testing
- `python -m py_compile app.py scripts/pretrain_tamil_gpt.py scripts/fine_tune_lyrics.py`
- `python -m pytest`
- `pip install -q datasets transformers torch gradio` *(fails: Could not find a version that satisfies the requirement datasets)*

------
https://chatgpt.com/codex/tasks/task_e_68a0575ac068832899eca848d5c1e48c